### PR TITLE
Added missing Templates group to template

### DIFF
--- a/haproxy_zbx_template.xml
+++ b/haproxy_zbx_template.xml
@@ -2,10 +2,20 @@
 <zabbix_export>
     <version>2.0</version>
     <date>2015-01-26T17:15:34Z</date>
+    <groups>
+        <group>
+            <name>Templates</name>
+        </group>
+    </groups>
     <templates>
         <template>
             <template>HAProxy</template>
             <name>HAProxy</name>
+            <groups>
+                <group>
+                    <name>Templates</name>
+                </group>
+            </groups>
             <applications>
                 <application>
                     <name>HAProxy</name>


### PR DESCRIPTION
Fixing the template, so it can be imported into zabbix 2.2/2.4

Else error like this will occur

```
Undefined index: groups [conf.import.php:130 → CConfigurationImport->import() → CConfigurationImport->gatherReferences() in /usr/share/zabbix/include/classes/import/CConfigurationImport.php:207]
Invalid argument supplied for foreach() [conf.import.php:130 → CConfigurationImport->import() → CConfigurationImport->gatherReferences() in /usr/share/zabbix/include/classes/import/CConfigurationImport.php:207]
Undefined index: groups [conf.import.php:130 → CConfigurationImport->import() → CConfigurationImport->processTemplates() → CTemplateImporter->import() → CTemplateImporter->resolveTemplateReferences() in /usr/share/zabbix/include/classes/import/importers/CTemplateImporter.php:231]
Invalid argument supplied for foreach() [conf.import.php:130 → CConfigurationImport->import() → CConfigurationImport->processTemplates() → CTemplateImporter->import() → CTemplateImporter->resolveTemplateReferences() in /usr/share/zabbix/include/classes/import/importers/CTemplateImporter.php:231]
No groups for template "HAProxy".
```
